### PR TITLE
Update Status function changes for `QueueStore`

### DIFF
--- a/internal/models/queue.go
+++ b/internal/models/queue.go
@@ -8,19 +8,19 @@ import (
 type QueueId Id
 
 type Queue struct {
-	// Unique ID for the queue. 
+	// Unique ID for the queue.
 	Id QueueId
 
-	// Name of the queue. The name is used in generating queue urls, for ex 
-	// https://simplq.me/j/<QueueName>. The storage layer guarantees sure that 
+	// Name of the queue. The name is used in generating queue urls, for ex
+	// https://simplq.me/j/<QueueName>. The storage layer guarantees sure that
 	// there is only one queue by a given name.
 	QueueName string
 
 	// Set to true if the queue is temporarily not issuing tokens
-	bool IsPaused
+	IsPaused bool
 
 	// Set to true if the queue has been deleted
-	bool IsDeleted
+	IsDeleted bool
 
 	// Tokens present in the queue.
 	Tokens []Token

--- a/internal/models/token.go
+++ b/internal/models/token.go
@@ -8,7 +8,7 @@ import (
 type TokenId Id
 
 type Token struct {
-	// Unique ID for the token. 
+	// Unique ID for the token.
 	Id TokenId
 
 	// Name of the token, typically name of the person to whom the token was
@@ -18,11 +18,11 @@ type Token struct {
 	// Contact Number
 	ContactNumber string
 
-	// Optional. Email ID if the queue collects email ID of users. 
+	// Optional. Email ID if the queue collects email ID of users.
 	EmailId string
 
 	// Set to true if the token has been deleted
-	bool IsDeleted
+	IsDeleted bool
 
 	// Number of times the token was notified.
 	NotifiedCount uint32

--- a/internal/persistence/persistence.go
+++ b/internal/persistence/persistence.go
@@ -26,6 +26,6 @@ type QueueStore interface {
 	// Read token by id.
 	ReadToken(models.TokenId)
 
-	// Set token status to new value.
-	UpdateTokenDeleteStatus(models.TokenId, bool)
+	// Delete token
+	RemoveToken(models.TokenId)
 }

--- a/internal/persistence/persistence.go
+++ b/internal/persistence/persistence.go
@@ -7,12 +7,15 @@ import (
 type QueueStore interface {
 	// Create a new queue and return the queue ID.
 	CreateQueue(models.Queue) models.QueueId
-	
+
 	// Read a queue by id.
 	ReadQueue(models.QueueId) models.Queue
 
-	// Set the queue status to new value.
-	UpdateQueueStatus(models.QueueId, models.QueueStatus)
+	// Set the queue pause status to new value.
+	UpdateQueuePauseStatus(models.QueueId, bool)
+
+	// Set the queue delete status to new value.
+	UpdateQueueDeleteStatus(models.QueueId, bool)
 
 	// Add a new token to the queue.
 	AddTokenToQueue(models.QueueId, models.Token)
@@ -21,5 +24,5 @@ type QueueStore interface {
 	ReadToken(models.TokenId)
 
 	// Set token status to new value.
-	UpdateTokenStatus(models.TokenId, models.TokenStatus)
+	UpdateTokenDeleteStatus(models.TokenId, bool)
 }

--- a/internal/persistence/persistence.go
+++ b/internal/persistence/persistence.go
@@ -11,11 +11,14 @@ type QueueStore interface {
 	// Read a queue by id.
 	ReadQueue(models.QueueId) models.Queue
 
-	// Set the queue pause status to new value.
-	UpdateQueuePauseStatus(models.QueueId, bool)
+	// Set the queue pause status to true
+	PauseQueue(models.QueueId)
 
-	// Set the queue delete status to new value.
-	UpdateQueueDeleteStatus(models.QueueId, bool)
+    // Set the queue pause status to false
+	ResumeQueue(models.QueueId)
+	
+    // Set the queue delete status to new value.
+	DeleteQueue(models.QueueId)
 
 	// Add a new token to the queue.
 	AddTokenToQueue(models.QueueId, models.Token)


### PR DESCRIPTION
Made these updates to the `QueueStore` since now we are using `bool` values for the paused and delete status
- Changed `UpdateQueueStatus` to 2 functions - `UpdateQueuePauseStatus` and `UpdateQueueDeleteStatus`
- Changed `UpdateTokenStatus` to `UpdateTokenDeleteStatus`